### PR TITLE
Support for variadic parameters for UDF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 # GNUmakefile won't exist yet, so we catch that case as well.
 
 
-all check install installdirs installcheck installcheck-parallel installcheck-good uninstall clean distclean maintainer-clean dist distcheck world check-world install-world installcheck-world uninstall clean distclean maintainer-clean:
+all check install installdirs installcheck installcheck-parallel installcheck-good uninstall clean distclean maintainer-clean dist distcheck world check-world install-world installcheck-world:
 	@if [ ! -f GNUmakefile ] ; then \
 	   echo "You need to run the 'configure' program first. See the file"; \
 	   echo "'INSTALL' for installation instructions." ; \

--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -1520,8 +1520,6 @@ heap_endscan(HeapScanDesc scan)
 #endif   /* !defined(HEAPDEBUGALL) */
 
 
-
-
 HeapTuple
 heap_getnext(HeapScanDesc scan, ScanDirection direction)
 {

--- a/src/backend/catalog/catalog.c
+++ b/src/backend/catalog/catalog.c
@@ -244,7 +244,7 @@ CopyRelPath(char *target, int targetMaxLen, RelFileNode rnode)
 char *
 GetDatabasePath(Oid dbNode, Oid spcNode)
 {
-	int 		pathlen;
+	int			pathlen;
 	char	   *path;
 	int 		snprintfResult;
 

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -372,46 +372,6 @@ _outJoinPlanInfo(StringInfo str, Join *node)
 }
 
 static void
-_outPlannedStmt(StringInfo str, PlannedStmt *node)
-{
-	WRITE_NODE_TYPE("PLANNEDSTMT");
-	
-	WRITE_ENUM_FIELD(commandType, CmdType);
-	WRITE_ENUM_FIELD(planGen, PlanGenerator);
-	WRITE_BOOL_FIELD(canSetTag);
-	WRITE_BOOL_FIELD(transientPlan);
-	
-	WRITE_NODE_FIELD(planTree);
-	
-	WRITE_NODE_FIELD(rtable);
-	
-	WRITE_NODE_FIELD(resultRelations);
-	WRITE_NODE_FIELD(utilityStmt);
-	WRITE_NODE_FIELD(intoClause);
-	WRITE_NODE_FIELD(subplans);
-	WRITE_NODE_FIELD(rewindPlanIDs);
-	WRITE_NODE_FIELD(returningLists);
-	
-	WRITE_NODE_FIELD(result_partitions);
-	WRITE_NODE_FIELD(result_aosegnos);
-	WRITE_NODE_FIELD(queryPartOids);
-	WRITE_NODE_FIELD(queryPartsMetadata);
-	WRITE_NODE_FIELD(numSelectorsPerScanId);
-	WRITE_NODE_FIELD(rowMarks);
-	WRITE_NODE_FIELD(relationOids);
-	WRITE_NODE_FIELD(invalItems);
-	WRITE_INT_FIELD(nCrossLevelParams);
-	WRITE_INT_FIELD(nMotionNodes);
-	WRITE_INT_FIELD(nInitPlans);
-	
-	/* Don't serialize policy */
-	WRITE_NODE_FIELD(sliceTable);
-	
-	WRITE_UINT64_FIELD(query_mem);
-	WRITE_NODE_FIELD(transientTypeRecords);
-}
-
-static void
 _outPlan(StringInfo str, Plan *node)
 {
 	WRITE_NODE_TYPE("PLAN");
@@ -4046,28 +4006,6 @@ _outAlterTypeStmt(StringInfo str, AlterTypeStmt *node)
 	WRITE_NODE_FIELD(encoding);
 }
 
-static void
-_outTupleDescNode(StringInfo str, TupleDescNode *node)
-{
-	Assert(node->tuple->tdtypeid == RECORDOID);
-
-	WRITE_NODE_TYPE("TUPLEDESCNODE");
-	WRITE_INT_FIELD(natts);
-	WRITE_INT_FIELD(tuple->natts);
-
-	int i = 0;
-	for (; i < node->tuple->natts; i++)
-		appendBinaryStringInfo(str, node->tuple->attrs[i], ATTRIBUTE_FIXED_PART_SIZE);
-
-	Assert(node->tuple->constr == NULL);
-
-	WRITE_OID_FIELD(tuple->tdtypeid);
-	WRITE_INT_FIELD(tuple->tdtypmod);
-	WRITE_INT_FIELD(tuple->tdqdtypmod);
-	WRITE_BOOL_FIELD(tuple->tdhasoid);
-	WRITE_INT_FIELD(tuple->tdrefcount);
-}
-
 /*
  * _outNode -
  *	  converts a Node into ascii string and append it to 'str'
@@ -4092,9 +4030,6 @@ _outNode(StringInfo str, void *obj)
 		appendStringInfoChar(str, '{');
 		switch (nodeTag(obj))
 		{
-			case T_PlannedStmt:
-				_outPlannedStmt(str,obj);
-				break;
 			case T_Plan:
 				_outPlan(str, obj);
 				break;
@@ -4893,9 +4828,6 @@ _outNode(StringInfo str, void *obj)
 			case T_AlterTypeStmt:
 				_outAlterTypeStmt(str, obj);
 				break;
-            case T_TupleDescNode:
-                _outTupleDescNode(str, obj);
-                break;
 
 			default:
 

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2985,39 +2985,6 @@ _readAlterTypeStmt(void)
 	READ_DONE();
 }
 
-static TupleDescNode *
-_readTupleDescNode(const char **str)
-{
-	READ_LOCALS(TupleDescNode);
-	READ_INT_FIELD(natts);
-
-	local_node->tuple = CreateTemplateTupleDesc(local_node->natts, false);
-
-	READ_INT_FIELD(tuple->natts);
-	if (local_node->tuple->natts > 0)
-	{
-		int i = 0;
-		for (; i < local_node->tuple->natts; i++)
-		{
-			memcpy(local_node->tuple->attrs[i], *str, ATTRIBUTE_FIXED_PART_SIZE);
-			(*str)+=ATTRIBUTE_FIXED_PART_SIZE;
-		}
-	}
-
-	READ_OID_FIELD(tuple->tdtypeid);
-	READ_INT_FIELD(tuple->tdtypmod);
-	READ_INT_FIELD(tuple->tdqdtypmod);
-	READ_BOOL_FIELD(tuple->tdhasoid);
-	READ_INT_FIELD(tuple->tdrefcount);
-
-	// Transient type don't have constraint.
-	local_node->tuple->constr = NULL;
-
-	Assert(local_node->tuple->tdtypeid == RECORDOID);
-
-	READ_DONE();
-}
-
 /*
  * Greenplum Database developers added code to improve performance over the
  * linear searching that existed in the postgres version of
@@ -3185,7 +3152,6 @@ static ParseNodeInfo infoAr[] =
 	{"TABLEVALUEEXPR", (ReadFn)_readTableValueExpr},
 	{"TARGETENTRY", (ReadFn)_readTargetEntry},
 	{"TRUNCATESTMT", (ReadFn)_readTruncateStmt},
-	{"TUPLEDESCNODE", (ReadFn)_readTupleDescNode},
 	{"TYPECAST", (ReadFn)_readTypeCast},
 	{"TYPENAME", (ReadFn)_readTypeName},
 	{"VACUUMSTMT", (ReadFn)_readVacuumStmt},

--- a/src/backend/utils/adt/acl.c
+++ b/src/backend/utils/adt/acl.c
@@ -1422,6 +1422,7 @@ convert_priv_string(text *priv_type_text)
 	return ACL_NO_RIGHTS;		/* keep compiler quiet */
 }
 
+
 /*
  * convert_any_priv_string: recognize privilege strings for has_foo_privilege
  *
@@ -1490,7 +1491,6 @@ convert_any_priv_string(text *priv_type_text,
  *		return NULL if the OID doesn't exist (rather than failing, as
  *		they did before Postgres 8.4).
  */
-
 
 /*
  * has_table_privilege_name_name

--- a/src/backend/utils/adt/arrayfuncs.c
+++ b/src/backend/utils/adt/arrayfuncs.c
@@ -4923,7 +4923,7 @@ array_fill_internal(ArrayType *dims, ArrayType *lbs,
 
 
 /*
- * UNNEST 
+ * UNNEST
  *    function name array_unnest() in Postgres.  Different in GP because we
  * added the function before we merged in the postgres function.
  */

--- a/src/backend/utils/adt/date.c
+++ b/src/backend/utils/adt/date.c
@@ -881,7 +881,6 @@ text_date(PG_FUNCTION_ARGS)
 				 errmsg("invalid input syntax for type date: \"%s\"",
 						DatumGetCString(DirectFunctionCall1(textout,
 													PointerGetDatum(str))))));
-	
 	sp = VARDATA(str);
 	dp = dstr;
 	for (i = 0; i < (VARSIZE(str) - VARHDRSZ); i++)

--- a/src/backend/utils/cache/inval.c
+++ b/src/backend/utils/cache/inval.c
@@ -459,7 +459,7 @@ RegisterSmgrInvalidation(RelFileNode rnode)
 {
 	AddSmgrInvalidationMessage(&transInvalInfo->CurrentCmdInvalidMsgs,
 							   rnode);
-							   
+
 	/*
 	 * As above, just in case there is not an associated catalog change.
 	 */

--- a/src/include/access/tupdesc.h
+++ b/src/include/access/tupdesc.h
@@ -79,6 +79,15 @@ typedef struct tupleDesc
 	int			tdrefcount;		/* reference count, or -1 if not counting */
 }	*TupleDesc;
 
+/*
+ * When dispatching a planned statement from QD to QEs, we need to be able
+ * to transmit TupleDescs. TupleDesc doesn't have the Node header, so for
+ * convenience of the read and out functions, we wrap them in TupleDescNode
+ * structs, which do.
+ *
+ * These are never serialized on disk, only in the read/outfast protocol,
+ * as part of PlannedStmts.
+ */
 typedef struct tupleDescNode
 {
 	NodeTag		type;

--- a/src/include/fmgr.h
+++ b/src/include/fmgr.h
@@ -21,19 +21,8 @@
 /* We don't want to include primnodes.h here, so make a stub reference */
 typedef struct Node *fmNodePtr;
 
-/* We are really stretching to avoid including nodes.h */
-typedef enum fmNodeTag
-{
-    fmT_ReturnSetInfo = 901
-} fmNodeTag;
-
 /* Likewise, avoid including stringinfo.h here */
 typedef struct StringInfoData *fmStringInfo;
-
-struct ExprContext;                     /* #include "nodes/execnodes.h" */
-struct tupleDesc;                       /* #include "access/tupdesc.h" */
-struct Tuplestorestate;                 /* #include "utils/tuplestore.h" */
-struct TuplestorePos;                   /* #include "utils/tuplestore.h" */
 
 
 /*
@@ -311,55 +300,6 @@ extern struct varlena *pg_detoast_datum_packed(struct varlena * datum);
 #define PG_RETURN_HEAPTUPLEHEADER(x)  PG_RETURN_POINTER(x)
 #define PG_RETURN_XID(x)	 return TransactionIdGetDatum(x)
 
-/*-------------------------------------------------------------------------
- *		Support for functions that might return sets (multiple rows)
- *
- * CDB: Moved these declarations to "fmgr.h" from "executor/execnodes.h"
- *-------------------------------------------------------------------------
- */
-
-/*
- * Set-result status returned by ExecEvalExpr()
- */
-typedef enum
-{
-	ExprSingleResult,			/* expression does not return a set */
-	ExprMultipleResult,			/* this result is an element of a set */
-	ExprEndResult				/* there are no more elements in the set */
-} ExprDoneCond;
-
-/*
- * Return modes for functions returning sets.  Note values must be chosen
- * as separate bits so that a bitmask can be formed to indicate supported
- * modes.
- */
-typedef enum
-{
-	SFRM_ValuePerCall = 0x01,	/* one value returned per call */
-	SFRM_Materialize = 0x02		/* result set instantiated in Tuplestore */
-} SetFunctionReturnMode;
-
-/*
- * When calling a function that might return a set (multiple rows),
- * a node of this type is passed as fcinfo->resultinfo to allow
- * return status to be passed back.  A function returning set should
- * raise an error if no such resultinfo is provided.
- */
-typedef struct ReturnSetInfo
-{
-	fmNodeTag           type;           /* enum NodeTag {T_ReturnSetInfo = 901} */
-	/* values set by caller: */
-	struct ExprContext *econtext;	    /* context function is being called in */
-	struct tupleDesc   *expectedDesc;	/* tuple descriptor expected by caller */
-	int			        allowedModes;	/* bitmask: return modes caller can handle */
-	/* result status from function (but pre-initialized by caller): */
-	SetFunctionReturnMode returnMode;	/* actual return mode */
-	ExprDoneCond        isDone;		    /* status for ValuePerCall mode */
-	/* fields filled by function in Materialize return mode: */
-	struct Tuplestorestate *setResult;  /* holds the complete returned tuple set */
-	struct tupleDesc   *setDesc;        /* actual descriptor for returned tuples */
-} ReturnSetInfo;
-
 
 /*-------------------------------------------------------------------------
  *		Support for detecting call convention of dynamically-loaded functions
@@ -632,5 +572,3 @@ extern void **find_rendezvous_variable(const char *varName);
 
 
 #endif   /* FMGR_H */
-
-

--- a/src/include/funcapi.h
+++ b/src/include/funcapi.h
@@ -18,7 +18,7 @@
 
 #include "fmgr.h"
 #include "access/tupdesc.h"
-#include "executor/execdesc.h"
+#include "executor/executor.h"
 #include "executor/tuptable.h"
 
 

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -1683,7 +1683,7 @@ typedef struct BitmapHeapScanState
 	struct HeapScanDescData *ss_currentScanDesc;
 	List	   *bitmapqualorig;
 	Node	   *tbm;
-	struct TBMIterateResult *tbmres;
+	TBMIterateResult *tbmres;
 } BitmapHeapScanState;
 
 /* ----------------

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -105,86 +105,88 @@ typedef uint32 AclMode;			/* a bitmask of privilege bits */
  */
 typedef struct Query
 {
-		NodeTag		type;
-		
-		CmdType		commandType;	/* select|insert|update|delete|utility */
-		
-		QuerySource querySource;	/* where did I come from? */
-		
-		bool		canSetTag;		/* do I set the command result tag? */
-		
-		Node	   *utilityStmt;	/* non-null if this is DECLARE CURSOR or a
+	NodeTag		type;
+
+	CmdType		commandType;	/* select|insert|update|delete|utility */
+
+	QuerySource querySource;	/* where did I come from? */
+
+	bool		canSetTag;		/* do I set the command result tag? */
+
+	Node	   *utilityStmt;	/* non-null if this is DECLARE CURSOR or a
 								 * non-optimizable statement */
-		
-		int			resultRelation; /* rtable index of target relation for
-									 * INSERT/UPDATE/DELETE; 0 for SELECT */
-		
-		IntoClause *intoClause;		/* target for SELECT INTO / CREATE TABLE AS */
-		
-		bool		hasAggs;		/* has aggregates in tlist or havingQual */
-		bool		hasWindFuncs;	/* has window function(s) in target list */
-		bool		hasSubLinks;	/* has subquery SubLink */
-		
-		List	   *rtable;			/* list of range table entries */
-		FromExpr   *jointree;		/* table join tree (FROM and WHERE clauses) */
-		
-		List	   *targetList;		/* target list (of TargetEntry) */
-		
-		List	   *returningList;	/* return-values list (of TargetEntry) */
-		
-		/*
-		 * A list of GroupClauses or GroupingClauses.  The order of
-		 * GroupClauses or GroupingClauses are based on input
-		 * queries. However, in each grouping set, all GroupClauses will
-		 * appear in front of GroupingClauses. See the following GROUP BY
-		 * clause:
-		 *
-		 *   GROUP BY ROLLUP(b,c),a, CUBE(e,d)
-		 *
-		 * the result list can be roughly represented as follows.
-		 *
-		 *    GroupClause(a) -->
-		 *    GroupingClause( ROLLUP, groupsets (GroupClause(b) --> GroupClause(c) ) ) -->
-		 *    GroupingClause( CUBE, groupsets (GroupClause(e) --> GroupClause(d) ) )
-		 */
-		List	   *groupClause;
-		
-		Node	   *havingQual;		/* qualifications applied to groups */
-		
-		List	   *windowClause;	/* defined window specifications */
-		
-		List	   *distinctClause; /* a list of SortGroupClause's */
-		
-		List	   *sortClause;		/* a list of SortGroupClause's */
 
-		List	   *scatterClause;  /* a list of tle's */
+	int			resultRelation; /* rtable index of target relation for
+								 * INSERT/UPDATE/DELETE; 0 for SELECT */
 
-		List	   *cteList; /* a list of CommonTableExprs in WITH clause */
-		bool 	   hasRecursive; /* Whether this query has a recursive WITH clause */
-		bool 	   hasModifyingCTE; /* has INSERT/UPDATE/DELETE in WITH clause */
+	IntoClause *intoClause;		/* target for SELECT INTO / CREATE TABLE AS */
 
-		Node	   *limitOffset;	/* # of result tuples to skip (int8 expr) */
-		Node	   *limitCount;		/* # of result tuples to return (int8 expr) */
-		
-		List	   *rowMarks;		/* a list of RowMarkClause's */
-		
-		Node	   *setOperations;	/* set-operation tree if this is top level of
-									 * a UNION/INTERSECT/EXCEPT query */
+	bool		hasAggs;		/* has aggregates in tlist or havingQual */
+	bool		hasWindFuncs;	/* has window function(s) in target list */
+	bool		hasSubLinks;	/* has subquery SubLink */
 
-	/* TODO Eventually we should remove these 4 members because they're not used here.
-	 *      Instead they're in PlannedStmt.  However, we need to read old formats, e.g.
-	 *      for catalog upgrade. So for now, it's easier to leave them here.
-	 */		
-		List	   *resultRelations;		/* Unused. Now in PlannedStmt. */
-		PartitionNode *result_partitions;	/* Unused. Now in PlannedStmt. */
-		List	   *result_aosegnos;		/* Unused. Now in PlannedStmt. */
-		List	   *returningLists; 		/* Unused. Now in PlannedStmt. */
-		
-		/* MPP: Used only on QD. Don't serialize.
-		 *      Holds the result distribution policy for SELECT ... INTO and
-		 *      set operations.
-		 */
-		struct GpPolicy  *intoPolicy;
+	List	   *rtable;			/* list of range table entries */
+	FromExpr   *jointree;		/* table join tree (FROM and WHERE clauses) */
+
+	List	   *targetList;		/* target list (of TargetEntry) */
+
+	List	   *returningList;	/* return-values list (of TargetEntry) */
+
+	/*
+	 * A list of GroupClauses or GroupingClauses.  The order of GroupClauses
+	 * or GroupingClauses are based on input queries. However, in each
+	 * grouping set, all GroupClauses will appear in front of GroupingClauses.
+	 * See the following GROUP BY clause:
+	 *
+	 * GROUP BY ROLLUP(b,c),a, CUBE(e,d)
+	 *
+	 * the result list can be roughly represented as follows.
+	 *
+	 * GroupClause(a) --> GroupingClause( ROLLUP, groupsets (GroupClause(b)
+	 * --> GroupClause(c) ) ) --> GroupingClause( CUBE, groupsets
+	 * (GroupClause(e) --> GroupClause(d) ) )
+	 */
+	List	   *groupClause;
+
+	Node	   *havingQual;		/* qualifications applied to groups */
+
+	List	   *windowClause;	/* defined window specifications */
+
+	List	   *distinctClause; /* a list of SortGroupClause's */
+
+	List	   *sortClause;		/* a list of SortGroupClause's */
+
+	List	   *scatterClause;	/* a list of tle's */
+
+	List	   *cteList;		/* a list of CommonTableExprs in WITH clause */
+	bool		hasRecursive;	/* Whether this query has a recursive WITH
+								 * clause */
+	bool		hasModifyingCTE;	/* has INSERT/UPDATE/DELETE in WITH clause */
+
+	Node	   *limitOffset;	/* # of result tuples to skip (int8 expr) */
+	Node	   *limitCount;		/* # of result tuples to return (int8 expr) */
+
+	List	   *rowMarks;		/* a list of RowMarkClause's */
+
+	Node	   *setOperations;	/* set-operation tree if this is top level of
+								 * a UNION/INTERSECT/EXCEPT query */
+
+	/*
+	 * TODO Eventually we should remove these 4 members because they're not
+	 * used here. Instead they're in PlannedStmt.  However, we need to read
+	 * old formats, e.g. for catalog upgrade. So for now, it's easier to leave
+	 * them here.
+	 */
+	List	   *resultRelations;	/* Unused. Now in PlannedStmt. */
+	PartitionNode *result_partitions;	/* Unused. Now in PlannedStmt. */
+	List	   *result_aosegnos;	/* Unused. Now in PlannedStmt. */
+	List	   *returningLists; /* Unused. Now in PlannedStmt. */
+
+	/*
+	 * MPP: Used only on QD. Don't serialize. Holds the result distribution
+	 * policy for SELECT ... INTO and set operations.
+	 */
+	struct GpPolicy *intoPolicy;
 } Query;
 
 /****************************************************************************
@@ -1114,12 +1116,12 @@ typedef struct AlterTableStmt
 	ObjectType	relkind;		/* type of object */
 
 	/* Workspace for use during AT processing/dispatch.  It might be better
-	 * to package there in a "context" node than to lay them out here. 
+	 * to package there in a "context" node than to lay them out here.
 	 */
 	List		 *oidmap;		/* For reindex_relation */
 	int			oidInfoCount;	/* Vector of TableOidInfo pointers: */
 	TableOidInfo *oidInfo;		/* MPP Allow for hierarchy of tables to alter */
-	
+
 } AlterTableStmt;
 
 typedef enum AlterTableType
@@ -1401,10 +1403,10 @@ typedef struct CreateStmt
 	char		relStorage;
 	struct GpPolicy  *policy;
 	Node       *postCreate;      /* CDB: parse and process after the CREATE */
-	List	   *deferredStmts;	/* CDB: Statements, e.g., partial indexes, that can't be 
+	List	   *deferredStmts;	/* CDB: Statements, e.g., partial indexes, that can't be
 								 * analyzed until after CREATE (until the target table
 								 * is created and visible). */
-	bool		is_part_child;	/* CDB: child table in a partition? Marked during analysis for 
+	bool		is_part_child;	/* CDB: child table in a partition? Marked during analysis for
 								 * interior or leaf parts of the new table.  Not marked for a
 								 * a partition root or ordinary table.
 								 */
@@ -1450,7 +1452,7 @@ typedef struct CreateExternalStmt
 								   data encoding */
 	List       *distributedBy;   /* what columns we distribute the data by */
 	struct GpPolicy  *policy;	/* used for writable tables */
-	
+
 } CreateExternalStmt;
 
 /* ----------------------
@@ -2022,7 +2024,7 @@ typedef struct CreateOpClassItem
 
 /* ----------------------
  *		DROP Statement, applies to:
- *        Table, External Table, Sequence, View, Index, Type, Domain, 
+ *        Table, External Table, Sequence, View, Index, Type, Domain,
  *        Conversion, Schema, Filespace
  * ----------------------
  */
@@ -2501,7 +2503,7 @@ typedef struct VacuumStmt
 
 	/*
 	 * AO segment file num to compact (integer).
-	 */ 
+	 */
 	List *appendonly_compaction_segno;
 
 	/*

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -166,6 +166,10 @@ typedef struct PlannedStmt
 	/* The overall memory consumption account (i.e., outside of an operator) */
 	MemoryAccount *memoryAccount;
 
+	/*
+	 * List of TupleDescNodes, one for each transient record type, when a
+	 * PlannedStmt is transferred from QD to QEs
+	 */
 	List	   *transientTypeRecords;
 } PlannedStmt;
 


### PR DESCRIPTION
User could use VARIADIC to specify parameter list when defining UDF if they want to use variadic parameters. It is easier for user to write only one variadic function instead of same name function with different parameters. An example for using variadic:

create function concat(text, variadic anyarray) returns text as $$
    select array_to_string($2, $1);
$$ language sql immutable strict;

select concat('%', 1, 2, 3, 4, 5);